### PR TITLE
Copy households.csv persons.csv from ActivitySim to Beam

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ In order to have BEAM to run correctly one needs to set the following settings:
 
 1. **skims_fname**: `gemini/10.activitySimODSkims.UrbanSim.TAZ.Full.csv.gz` The full skim file that contains all Origin Destinations pairs with ActivitySim path types.
 2. **beam_config**: `gemini/activitysim-base-from-60k-input.conf` Path to beam config. This path must be relative to `beam_local_input_folder` and `region`. The BEAM docker container is provided with this config as an input.
-3. **beam_plans**: `gemini/activitysim-plans-base-2010-cut-60k/plans.csv.gz` File with BEAM plans that is going to be replace with the ActiveSim output.
+3. **beam_scenario_folder**: `gemini/activitysim-plans-base-2010-cut-60k` Folder with BEAM scenario where ActivitySim output goes. Files from this folder are a scenario input for BEAM.
 4. **beam_local_input_folder**: `pilates/beam/production/` Path to BEAM input folder. This folder is going to be mapped to the BEAM container input folder.
 5. **beam_local_output_folder**: `pilates/beam/beam_output/` The BEAM output is going to be saved here. In order to have a clean run this directory should be empty before start.
 

--- a/pilates/beam/preprocessor.py
+++ b/pilates/beam/preprocessor.py
@@ -8,21 +8,27 @@ logger = logging.getLogger(__name__)
 
 def copy_plans_from_asim(settings, year, replanning_iteration=-1):
     asim_output_data_dir = settings['asim_local_output_folder']
-    plans_path = os.path.join(asim_output_data_dir, 'final_plans.csv')
-    beam_local_plans = os.path.join(
+    beam_scenario_folder = os.path.join(
         settings['beam_local_input_folder'],
         settings['region'],
-        settings['beam_plans'])
+        settings['beam_scenario_folder'])
 
-    logger.info(
-        "Copying asim plans %s to beam input plans %s",
-        plans_path, beam_local_plans)
+    def copy_with_compression_asim_file_to_beam(asim_file_name, beam_file_name):
+        asim_file_path = os.path.join(asim_output_data_dir, asim_file_name)
+        beam_file_path = os.path.join(beam_scenario_folder, beam_file_name)
+        logger.info("Copying asim file %s to beam input scenario file %s", asim_file_path, beam_file_path)
 
-    with open(plans_path, 'rb') as f_in, gzip.open(
-            beam_local_plans, 'wb') as f_out:
-        f_out.writelines(f_in)
+        with open(asim_file_path, 'rb') as f_in, gzip.open(
+                beam_file_path, 'wb') as f_out:
+            f_out.writelines(f_in)
+
+    copy_with_compression_asim_file_to_beam('final_plans.csv', 'plans.csv.gz')
+    if replanning_iteration == -1:
+        copy_with_compression_asim_file_to_beam('final_households.csv', 'households.csv.gz')
+        copy_with_compression_asim_file_to_beam('final_persons.csv', 'persons.csv.gz')
 
     if settings.get('final_asim_plans_folder', False):
+        beam_local_plans = os.path.join(beam_scenario_folder, 'plans.csv.gz')
         replanning_iteration_number = replanning_iteration + 1
         final_plans_name = f"final_plans_{year}_{replanning_iteration_number:02d}.csv.gz"
         final_plans_location = os.path.join(settings['final_asim_plans_folder'], final_plans_name)

--- a/pilates/beam/preprocessor.py
+++ b/pilates/beam/preprocessor.py
@@ -6,7 +6,7 @@ import shutil
 logger = logging.getLogger(__name__)
 
 
-def copy_plans_from_asim(settings, year, replanning_iteration=-1):
+def copy_plans_from_asim(settings, year, replanning_iteration_number=0):
     asim_output_data_dir = settings['asim_local_output_folder']
     beam_scenario_folder = os.path.join(
         settings['beam_local_input_folder'],
@@ -23,13 +23,12 @@ def copy_plans_from_asim(settings, year, replanning_iteration=-1):
             f_out.writelines(f_in)
 
     copy_with_compression_asim_file_to_beam('final_plans.csv', 'plans.csv.gz')
-    if replanning_iteration == -1:
+    if replanning_iteration_number == 0:
         copy_with_compression_asim_file_to_beam('final_households.csv', 'households.csv.gz')
         copy_with_compression_asim_file_to_beam('final_persons.csv', 'persons.csv.gz')
 
     if settings.get('final_asim_plans_folder', False):
         beam_local_plans = os.path.join(beam_scenario_folder, 'plans.csv.gz')
-        replanning_iteration_number = replanning_iteration + 1
         final_plans_name = f"final_plans_{year}_{replanning_iteration_number:02d}.csv.gz"
         final_plans_location = os.path.join(settings['final_asim_plans_folder'], final_plans_name)
         logger.info("Copying asim plans %s to final asim folder %s", beam_local_plans, final_plans_location)

--- a/run.py
+++ b/run.py
@@ -344,7 +344,7 @@ def generate_activity_plans(
     return
 
 
-def run_traffic_assignment(settings, year, client):
+def run_traffic_assignment(settings, year, client, replanning_iteration_number=0):
     """
     This step will run the traffic simulation platform and
     generate new skims with updated congested travel times.
@@ -378,7 +378,7 @@ def run_traffic_assignment(settings, year, client):
             "{2} outputs".format(
                 year, travel_model, activity_demand_model))
         formatted_print(print_str)
-        beam_pre.copy_plans_from_asim(settings, year)
+        beam_pre.copy_plans_from_asim(settings, year, replanning_iteration_number)
 
     # 3. RUN BEAM
     logger.info(
@@ -479,8 +479,8 @@ def run_replanning_loop(settings, forecast_year):
     last_asim_step = settings['replan_after']
 
     for i in range(replan_iters):
-
-        print_str = ('Replanning Iteration {0}'.format(i + 1))
+        replanning_iteration_number = i + 1
+        print_str = ('Replanning Iteration {0}'.format(replanning_iteration_number))
         formatted_print(print_str)
 
         # a) format new skims for asim
@@ -503,16 +503,8 @@ def run_replanning_loop(settings, forecast_year):
                 stream=True, stderr=True, stdout=docker_stdout):
             print(log)
 
-        # c) format updated plans for beam
-        print_str = (
-            "Generating {0} {1} input data from "
-            "{2} outputs".format(
-                forecast_year, travel_model, activity_demand_model))
-        formatted_print(print_str)
-        beam_pre.copy_plans_from_asim(settings, year, i)
-
         # e) run BEAM
-        run_traffic_assignment(settings, year, client)
+        run_traffic_assignment(settings, year, client, replanning_iteration_number)
 
     return
 

--- a/settings.yaml
+++ b/settings.yaml
@@ -56,7 +56,7 @@ usim_formattable_command: "-r {0} -i {1} -y {2} -f {3} -ss {4}"
 beam_config: gemini/activitysim-base-from-60k-input.conf
 beam_local_input_folder: pilates/beam/production/
 beam_local_output_folder: pilates/beam/beam_output/
-beam_plans: gemini/activitysim-plans-base-2010-cut-60k/plans.csv.gz
+beam_scenario_folder: gemini/activitysim-plans-base-2010-cut-60k
 beam_memory: "100g"
 skim_zone_source_id_col: objectid
 replan_iters: 0


### PR DESCRIPTION
1. Added copying of `households.csv` and `persons.csv` along with `plans.csv` to Beam scenario folder after full population run of ActivitySim. When ActivitySim does replanning iterations only `plans.csv` file is copied. Now `settings.yaml` contains `beam_scenario_folder` parameter instead of `beam_plans`.
2. Now `copy_plans_from_asim` is called only from `run_traffic_assignment` in order to avoid double file copying.
3. `copy_plans_from_asim` has parameter `replanning_iteration_number`. One needs to pass `i + 1` there.